### PR TITLE
[Fix 27] fix relink of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@ SPLIT 	= ./split/split.c
 COM	  	= ./command_execution/*
 BUILTIN = ./builtin_commands/echo/*
 
-all:
-	$(CC) $(FLAGS) $(SPLIT) $(COM) $(BUILTIN) main.c -lreadline -o minishell
+TARGET  = minishell
+
+$(TARGET):
+	$(CC) $(FLAGS) $(SPLIT) $(COM) $(BUILTIN) main.c -lreadline -o $(TARGET)
 
 rm:
-	rm minishell
+	rm $(TARGET)
 
 norm:
 	norminette


### PR DESCRIPTION
```
TARGET = minishell
```
という変数を追加してから，`all` という rule を削除して，代わりに`$(TARGET)`というルールに変更しました。`all`の部分を($TARGET)に変更しただけです。